### PR TITLE
Feature/us18/exibir telefone na tabela de associados (#45)

### DIFF
--- a/src/pages/Associados/Associados.tsx
+++ b/src/pages/Associados/Associados.tsx
@@ -45,6 +45,7 @@ export function Associados() {
                                 <th>Nome</th>
                                 <th>Documento</th>
                                 <th>Email</th>
+                                <th>Telefone</th>
                                 <th>Status</th>
                             </tr>
                         </thead>
@@ -54,6 +55,7 @@ export function Associados() {
                                     <td><strong>{member.nome}</strong></td>
                                     <td>{member.cpfCnpj}</td>
                                     <td>{member.email}</td>
+                                    <td>{member.telefone}</td>
                                     <td>
                                         <Badge variant={member.status === 'ativo' ? 'success' : 'warning'}>
                                             {member.status === 'ativo' ? 'Ativo' : 'Inativo'}


### PR DESCRIPTION
° Nova coluna adicionada  "Telefone" visível na tabela

° Exibindo o telefone de cada associado corretamente

<img width="1366" height="768" alt="Exibindo telefone de associados" src="https://github.com/user-attachments/assets/9ef9a4d9-2f07-49d1-8209-e5ebea75906c" />
